### PR TITLE
Empty label fix

### DIFF
--- a/src/CheckBox.js
+++ b/src/CheckBox.js
@@ -50,7 +50,11 @@ class CheckBox extends Component {
         return (
             <View style={[styles.contentStyle, { flexDirection }]}>
                 {this._renderIcon.call(this, iconName)}
-                {label && < Text style={labelStyle}>{label}</Text>}
+                {
+                    label ?
+                    <Text style={labelStyle}>{label}</Text>
+                    : null
+                }
             </View>
         )
     }


### PR DESCRIPTION
Fix RawText "" must be wrapped in an explicit <Text> component on empty label, e.g.
`
<Checkbox
	label=''
	iconSize={28}
	iconName="iosCircleFill"	//or iosCircleMix?
	checkedColor="#187EFB"
	uncheckedColor="#fff"
/>
`
will thrown error:
![iphone 6 ios 10 3 14e8301 2017-06-15 19-47-04](https://user-images.githubusercontent.com/2942880/27192447-14a02244-5204-11e7-8cb3-3dc0a25b157f.png)
